### PR TITLE
Remove pedestal wrapping from rendered exceptions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [prone "1.0.0"]
+                 [prone "1.0.1"]
                  [ring/ring-core "1.4.0"]
                  [io.pedestal/pedestal.service "0.4.1"]])

--- a/src/prone_pedestal/interceptor/exceptions.clj
+++ b/src/prone_pedestal/interceptor/exceptions.clj
@@ -32,5 +32,7 @@
      :error
      (fn [{:keys [request] :as ctx} e]
        (when-not (and skip-prone? (skip-prone? request))
-         (assoc ctx :response
-           (prone/exceptions-response request e app-namespaces))))}))
+         (let [wrapped-e (-> e ex-data :exception)]
+           (assoc ctx :response
+                  (prone/exceptions-response
+                   request wrapped-e app-namespaces)))))}))


### PR DESCRIPTION
When an exception is thrown Pedestal wraps it to a new clojure.lang.ExceptionInfo instance. This hides the application frames from Prone and takes away one of the main points of Prone. Pedestal attaches the original exception into wrapped exception under :exception key. This PR changes exception rendering to use the original exception instead of Pedestal wrapped exception thus making the original failing code visible in stack frames and allowing Prone to detect application frames correctly.
